### PR TITLE
Fatal error when install php >= 8.0

### DIFF
--- a/siberian/app/sae/modules/Core/Model/Lib/Facebook.php
+++ b/siberian/app/sae/modules/Core/Model/Lib/Facebook.php
@@ -32,7 +32,7 @@ class Core_Model_Lib_Facebook extends Core_Model_Default {
 
     public static function getSecretKey() {
         //first check app key, else use global key
-        $app_related_secret_key = self::getApplication()->getFacebookKey();
+        $app_related_secret_key = (new Core_Model_Default())->getApplication()->getFacebookKey();
         $secret_key = !empty($app_related_secret_key) ?
             $app_related_secret_key :
             Api_Model_Key::findKeysFor('facebook')->getSecretKey() ;


### PR DESCRIPTION
Fatal error: Uncaught Error: Non-static method Core\Model\Base::getApplication() cannot be called statically in /siteroot/app/sae/modules/Core/Model/Lib/Facebook.php:35