### PR TITLE
Error when update to php 8.0 and more

### DIFF
--- a/siberian/app/sae/modules/Media/Model/Db/Table/Gallery/Video/Youtube.php
+++ b/siberian/app/sae/modules/Media/Model/Db/Table/Gallery/Video/Youtube.php
@@ -5,7 +5,7 @@ class Media_Model_Db_Table_Gallery_Video_Youtube extends Core_Model_Db_Table {
     protected $_name = "media_gallery_video_youtube";
     protected $_primary = "gallery_id";
 
-    public function getFields() {
+    public function getFields($tablename = null) {
         $fields = array_keys($this->_db->describeTable($this->_name));
         return array_combine($fields, $fields);
     }


### PR DESCRIPTION
Fatal error: Declaration of Media_Model_Db_Table_Gallery_Video_Youtube::getFields() must be compatible with Core_Model_Db_Table::getFields($tablename = null) in /siteroot/app/sae/modules/Media/Model/Db/Table/Gallery/Video/Youtube.php on line 8	