### PR TITLE
Updated CDVWKInAppBrowser.m to fix iOS link opening issue

### DIFF
--- a/ionic/platforms/browser/cordova/plugins/InAppBrowser/src/ios/CDVWKInAppBrowser.m
+++ b/ionic/platforms/browser/cordova/plugins/InAppBrowser/src/ios/CDVWKInAppBrowser.m
@@ -357,9 +357,10 @@ static CDVWKInAppBrowser* instance = nil;
 
 - (void)openInSystem:(NSURL*)url
 {
-    if ([[UIApplication sharedApplication] openURL:url] == NO) {
+    if (![[UIApplication sharedApplication] canOpenURL:url]) {
         [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:CDVPluginHandleOpenURLNotification object:url]];
-        [[UIApplication sharedApplication] openURL:url];
+    } else {
+        [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
     }
 }
 

--- a/ionic/platforms/ios/AppsMobileCompany/Plugins/InAppBrowser/CDVWKInAppBrowser.m
+++ b/ionic/platforms/ios/AppsMobileCompany/Plugins/InAppBrowser/CDVWKInAppBrowser.m
@@ -357,9 +357,10 @@ static CDVWKInAppBrowser* instance = nil;
 
 - (void)openInSystem:(NSURL*)url
 {
-    if ([[UIApplication sharedApplication] openURL:url] == NO) {
+    if (![[UIApplication sharedApplication] canOpenURL:url]) {
         [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:CDVPluginHandleOpenURLNotification object:url]];
-        [[UIApplication sharedApplication] openURL:url];
+    } else {
+        [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
     }
 }
 

--- a/siberian/var/apps/ionic/ios/AppsMobileCompany/Plugins/InAppBrowser/CDVWKInAppBrowser.m
+++ b/siberian/var/apps/ionic/ios/AppsMobileCompany/Plugins/InAppBrowser/CDVWKInAppBrowser.m
@@ -357,9 +357,10 @@ static CDVWKInAppBrowser* instance = nil;
 
 - (void)openInSystem:(NSURL*)url
 {
-    if ([[UIApplication sharedApplication] openURL:url] == NO) {
+    if (![[UIApplication sharedApplication] canOpenURL:url]) {
         [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:CDVPluginHandleOpenURLNotification object:url]];
-        [[UIApplication sharedApplication] openURL:url];
+    } else {
+        [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
     }
 }
 


### PR DESCRIPTION
This update resolves an issue where links were not opening on iOS devices due to the deprecated openURL method. The fix replaces openURL: with openURL:options:completionHandler:, ensuring compatibility with iOS 10+ and preventing deprecation warnings.

- **### Changes Made:**
Updated CDVWKInAppBrowser.m to use openURL:options:completionHandler: instead of the deprecated openURL:.
Ensured backward compatibility with older iOS versions.
Verified that the fix does not impact Android functionality.

- **### Impact & Testing:**
Links now open correctly on all supported iOS versions.
The fix has been tested on real iOS devices.
No impact on Android functionality.

- **### - URL handling improvements:**

* [`ionic/platforms/browser/cordova/plugins/InAppBrowser/src/ios/CDVWKInAppBrowser.m`](diffhunk://#diff-352bd46e9268171bf08318af59688457667d8e50e74f5f0195a98a179d5fe706L360-R363): Updated `openInSystem` method to check if the URL can be opened before attempting to open it, and to use `openURL:options:completionHandler:`.
* [`ionic/platforms/ios/AppsMobileCompany/Plugins/InAppBrowser/CDVWKInAppBrowser.m`](diffhunk://#diff-352bd46e9268171bf08318af59688457667d8e50e74f5f0195a98a179d5fe706L360-R363): Updated `openInSystem` method to check if the URL can be opened before attempting to open it, and to use `openURL:options:completionHandler:`.
* [`siberian/var/apps/ionic/ios/AppsMobileCompany/Plugins/InAppBrowser/CDVWKInAppBrowser.m`](diffhunk://#diff-352bd46e9268171bf08318af59688457667d8e50e74f5f0195a98a179d5fe706L360-R363): Updated `openInSystem` method to check if the URL can be opened before attempting to open it, and to use `openURL:options:completionHandler:`.

- **Developer Information:**
This contribution was made by ---, developer at Migastone International Srl.
